### PR TITLE
Restores admin theme for Content Browser module's entity browser rout…

### DIFF
--- a/material_admin_support.services.yml
+++ b/material_admin_support.services.yml
@@ -1,0 +1,5 @@
+services:
+  material_admin_support.route_subscriber:
+    class: Drupal\material_admin_support\Routing\RouteSubscriber
+    tags:
+      - { name: 'event_subscriber' }

--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\material_Admin_support\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Drupal\Core\Routing\RoutingEvents;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Modifies entity browser routes to use the admin theme.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * Routes which shouldn't be themed with the admin theme.
+   *
+   * @var array
+   */
+  protected $content_browser_routes = [
+    'entity_browser.browse_content',
+    'entity_browser.browse_content_iframe',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    foreach ($this->content_browser_routes as $content_browser_route) {
+      if ($route = $collection->get($content_browser_route)) {
+        $route->setOption('_admin_route', TRUE);
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events = parent::getSubscribedEvents();
+    $events[RoutingEvents::ALTER] = ['onAlterRoutes', -1];
+    return $events;
+  }
+
+}


### PR DESCRIPTION
…es (overriding the override in content browser module)